### PR TITLE
(maint) Change name of Enhancement label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -67,9 +67,10 @@
   color: "EB6420"
   description: "Issues that are duplicates of other issues"
   aliases: ["duplicate", "duplicates"]
-- name: "Enhancement"
+- name: "Improvement"
   color: "0052CC"
   description: "Issues that enhances existing functionality, or adds new features"
+  aliases: ["Enhancement"]
 - name: "Feature"
   color: "5319E7"
   description: "Issues that introduce new functionality to the project, instead of updating existing functionality"


### PR DESCRIPTION
## Description Of Changes

This commit changes the default label for this type of thing to be Improvement, and also to add an alias, so that existing labels with Enhancement will be changed to be Improvement.

## Motivation and Context

Elsewhere in our documentation, we use Improvement, rather than Enhancement.  

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A