### PR TITLE
(maint) Adjust commands for Chocolatey CLI breaking changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/zReportIssue.yml
+++ b/.github/ISSUE_TEMPLATE/zReportIssue.yml
@@ -73,7 +73,7 @@ body:
         * Operating System: To get this information run `[System.Environment]::OSVersion.version.tostring()`
         * Windows PowerShell Version: Run `$PSVersionTable`
         * Chocolatey CLI Version: Run `choco --version`
-        * Chocolatey Licensed Extension version (Run `choco list chocolatey.extension --local --exact`):
+        * Chocolatey Licensed Extension version (Run `choco list chocolatey.extension --exact` (If running a Chocolatey CLI version less than v2.0.0, add `--local-only`)):
         * Chocolatey License type (Professional / Business / ?)
         * Terminal/Emulator: Some knowledge from you is necessary here. CMD, Windows PowerShell, PowerShell Core, Microsoft Terminal, Cmder, and more are possible known terminals or emulators.
       value: |
@@ -90,7 +90,7 @@ body:
     attributes:
       label: Installed Packages
       description: |
-        Sometimes one or more packages installed may be the cause of the problem. Please include the information from the command `choco list -lo`. If this is part of the installation of Chocolatey CLI or no packages
+        Sometimes one or more packages installed may be the cause of the problem. Please include the information from the command `choco list ` (If running a Chocolatey CLI version less than v2.0.0, add `--local-only`). If this is part of the installation of Chocolatey CLI or no packages
         are installed (not even Chocolatey); please add `N/A` instead.
       render: bash
     validations:


### PR DESCRIPTION
## Description Of Changes

Adjusts to the removal/breakage of `--local-only` from Chocolatey CLI v2.0.0 when not using `--limit-output`

## Motivation and Context

There have been a number of issues recently on the chocolatey/choco repository where people are having issues running the commands provided for listing packages and chocolatey.extension. We want the commands to work, so the issues actually contain the needed information.

## Testing
N/A

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A, documentation
