### PR TITLE
(#33) Add GRM templates and initial syncing

### DIFF
--- a/.github/GitReleaseMaanger/.templates/default/create/footer.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/create/footer.sbn
@@ -1,0 +1,10 @@
+{{ if config.create.include_footer }}
+
+### {{ config.create.footer_heading }}
+
+{{  if config.create.milestone_replace_text
+        replace_milestone_title config.create.footer_content config.create.milestone_replace_text milestone.target.title
+    else
+        config.create.footer_content
+    end
+end }}

--- a/.github/GitReleaseMaanger/.templates/default/index.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/index.sbn
@@ -1,0 +1,10 @@
+{{-
+    include 'release-info'
+    if milestone.target.description
+        include 'milestone'
+    end
+    include 'issues' | string.rstrip
+    if template_kind == "CREATE"
+        include 'create/footer'
+    end
+~}}

--- a/.github/GitReleaseMaanger/.templates/default/issue-details.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/issue-details.sbn
@@ -1,0 +1,5 @@
+### {{ issue_label }}
+
+{{ for issue in issues.items[issue_label]
+    include 'issue-note'
+end }}

--- a/.github/GitReleaseMaanger/.templates/default/issue-note.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/issue-note.sbn
@@ -1,0 +1,6 @@
+{{
+    if issue_label == "Bug"
+}}- Fix - {{ issue.title }} - see [#{{ issue.number }}]({{ issue.html_url }}).
+{{  else
+}}- {{ issue.title }} - see [#{{ issue.number }}]({{ issue.html_url }}).
+{{  end -}}

--- a/.github/GitReleaseMaanger/.templates/default/issues.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/issues.sbn
@@ -1,0 +1,4 @@
+
+{{ for issue_label in issue_labels
+    include 'issue-details'
+end }}

--- a/.github/GitReleaseMaanger/.templates/default/milestone.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/milestone.sbn
@@ -1,0 +1,2 @@
+
+{{ milestone.target.description }}

--- a/.github/GitReleaseMaanger/.templates/default/release-info.sbn
+++ b/.github/GitReleaseMaanger/.templates/default/release-info.sbn
@@ -1,0 +1,10 @@
+{{
+    if issues.count > 0
+        if commits.count > 0
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}) which resulted in [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?closed=1) being closed.
+{{      else
+}}As part of this release we had [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?closed=1) closed.
+{{      end
+    else if commits.count > 0
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}).
+{{  end -}}

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,6 +1,12 @@
 group:
   # All repositories that need to sync common files
   - files:
+      - source: .github/GitReleaseManager/.templates
+        dest: .templates
+    repos: |
+      chocolatey/choco
+      chocolatey/repository-template
+  - files:
       - source: .github/workflows/label-sync.yml
         dest: .github/workflows/label-sync.yml
         replace: false # we do not want to replace the file, in case of customizations


### PR DESCRIPTION
## Description Of Changes

This commit adds the default GRM templates which shouldn't be used across all the repositories that use GRM.  In addition, an initial sync has been configured to the chocolatey/choco repository, to test out that everything is working, and then a follow up commit will be done to expand the syncing to all required repositories.

## Motivation and Context

This will reduce the amount of work that needs to be done to update/change GRM templates across the repositories that are using it.

## Testing

Merging this PR will verify whether the initial file sync will work, and from there, it can be expanded to other repositories.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #33