### PR TITLE
(maint) Add label sync for boxstarter repo

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -23,6 +23,7 @@ group:
         dest: .github/workflows/label-sync.yml
         replace: false # we do not want to replace the file, in case of customizations
     repos: |
+      chocolatey/boxstarter
       chocolatey/docs
       chocolatey-community/chocolatey-au
       chocolatey/NuGet.Client
@@ -35,7 +36,6 @@ group:
       # chocolatey/chocolatey.org
       # chocolatey/chocolatey-ansible
       # chocolatey/choco-quickstart-scripts
-      # chocolatey/boxstarter
       # chocolatey/boxstarter.org
       # chocolatey/cChoco
       # chocolatey/rhino-licensing


### PR DESCRIPTION
## Description Of Changes
Adds the label synchronisation to the github.com/chocolatey/bostarter repository.

NOTE: I've ensured that any labels in the Boxstarter repository that would be removed by this sync, have no issues associated with them. I have also ensured that Actions are enabled on the boxstarter repository.

## Motivation and Context
We're rolling this out across all our repositories.

## Testing
This is already used in many  repositories.

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
N/A