### PR TITLE
(maint) Add BreakingChange label to GRM config

### DIFF
--- a/.github/GitReleaseManager/GitReleaseManager.yaml
+++ b/.github/GitReleaseManager/GitReleaseManager.yaml
@@ -1,5 +1,6 @@
 issue-labels-include:
   - Breaking Change
+  - BreakingChange
   - Deprecate
   - Feature
   - C4B Feature
@@ -18,6 +19,9 @@ issue-labels-alias:
   - name:    Bug
     header:  Bug Fix
     plural:  Bug Fixes
+  - name:    Breaking Change
+    header:  Breaking Change
+    plural:  Breaking Changes
   - name:    Deprecate
     header:  Deprecated Feature
     plural:  Deprecated Features


### PR DESCRIPTION
## Description Of Changes

It was found that one of the labels we use on internal repository were
not part of the GitReleaseManager configuration. This commit attempts to
rectify this to include the missing BreakingChange label along with
necessary header values to the initial configuration.

## Motivation and Context

When the GitReleaseManager configuration  does not include all the labels that we use, we have to make manual modifications when creating a release for a product.

## Testing

A simial change was made during the latest release of CCM as were tested as part of that.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Configuration change.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A