### PR TITLE
(maint) Add space between words in labels

### DIFF
--- a/.github/GitReleaseManager/GitReleaseManager.yaml
+++ b/.github/GitReleaseManager/GitReleaseManager.yaml
@@ -9,7 +9,7 @@ issue-labels-include:
   - Dependency Change
 issue-labels-exclude:
   - Internal Refactoring
-  - BuildAutomation
+  - Build Automation
   - NO RELEASE NOTES
 issue-labels-alias:
   - name:    Documentation

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -41,17 +41,17 @@
 - name: "Blocked - External"
   color: "5319E7"
   description: "The issue or pull request is not fixable without a change in a upstream/external library"
-- name: "BreakingChange"
+- name: "Breaking Change"
   color: "5319E7"
   description: "The issue will introduce backwards incompatible changes"
-  aliases: ["Breaking Change"]
+  aliases: ["BreakingChange"]
 - name: "Bug"
   color: "D73A4A"
   description: "Issues where something has happened which was not expected or intended"
-- name: "BuildAutomation"
+- name: "Build Automation"
   color: "0052CC"
   description: "Issues for changes to the build system, without functional changes needed to the project"
-  aliases: ["Build Automation", "Build"]
+  aliases: ["BuildAutomation", "Build"]
 - name: "CoreTeam"
   color: "F7C6C7"
   description: "Issues that will only be accepted from the core Chocolatey Team"
@@ -81,10 +81,10 @@
 - name: "hacktoberfest-accepted"
   color: "1D76DB"
   description: "Pull Requests opened during hacktoberfest, and has been accepted by a team member"
-- name: "HasDependency"
+- name: "Has Dependency"
   color: "8E44AD"
   description: "This issue has a related issue that would need to be addressed before this issue can be closed"
-  aliases: ["Has related issue"]
+  aliases: ["Has related issue", "HasDependency"]
 - name: "IN MANUAL TEST SUITE"
   color: "8E44AD"
   description: "These are things that are documented to test as part of a release"


### PR DESCRIPTION
## Description Of Changes

This updates the common labels that is synchronized to different
repositories to introduce a space between the words, making them easier
to read.

## Motivation and Context

To make our labels more readable, as well as after discussion with @gep13 it was decided that it would be better to add spaces, than add additional configurations to repositories behaving differently.

## Testing

Not possibly to test until changes are merged in to a synchronized repository.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A