### PR TITLE
(feat) Add new Lock Closed Issues and PRs workflow and file sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -139,3 +139,14 @@ group:
       chocolatey/docs
       chocolatey/chocolatey-ansible
       chocolatey/home
+  - files:
+      - source: .github/workflows/lock-closed.yml
+        dest: .github/workflows/lock-closed.yml
+        replace: true # we want to replace this file to ensure consistent policy across all repositories
+    repos: |
+      chocolatey/rhino-licensing
+    # chocolatey/choco
+      # chocolatey/ChocolateyGUI
+      # chocolatey/docs
+      # chocolatey/chocolatey-ansible
+      # chocolatey/home

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,0 +1,36 @@
+name: "Lock Closed Issues and PRs"
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/dessant/lock-threads
+      - uses: dessant/lock-threads@v5.0.1
+        with:
+          exclude-issue-closed-before: "2024-06-01T00:00:00Z"
+          issue-inactive-days: 30
+          issue-lock-reason: "resolved"
+          issue-comment: >
+            This issue has been automatically locked since as there has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-inactive-days: 30
+          exclude-pr-closed-before: "2024-06-01T00:00:00Z"
+          pr-lock-reason: "resolved"
+          discussion-inactive-days: 60
+          pr-comment: >
+            This pull request has been automatically locked since there has not been any recent activity after it was closed.
+            Please open a new pull request.
+          log-output: true


### PR DESCRIPTION
## Description Of Changes
Added a workflow that will lock closed issues after 30 days, PR's and discussions after 60 days.

I have added this to only lock issues closed after 1 June 2024 (as I feel they are more likely to get later comments on).

This is limited to chocolatey\rhino-licensing just now as it only has a few issues and PR's and will have minimal impact if things go wrong (which they shouldn't, but belt and braces). The goal would be to roll it out to other repositories slowly. 

## Motivation and Context
Many times, comments are being added to old issues that are not helpful. Often the team are required to spend time responding to clarify that the issue is closed and that a new issue should be raised so we can capture the relevant information.

## Testing
This was tested over [here](https://github.com/pauby/hugo-theme-docport/actions/runs/12181800255). The date was limited to exclude issues before 1 June 2022, and as a result locked [this issue from 2 June 2022](https://github.com/pauby/hugo-theme-docport/issues/5), but did not lock [this issue from 10 May 2022](https://github.com/pauby/hugo-theme-docport/issues/5).

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
N/A