### PR TITLE
Update grm

### DIFF
--- a/.github/GitReleaseManager/.templates/contributors/contributor-details.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/contributor-details.sbn
@@ -1,0 +1,1 @@
+<a href="{{contributor.html_url}}"><img src="{{contributor.avatar_url}}" alt="{{contributor.login}}" height="32" width="32"/></a> 

--- a/.github/GitReleaseManager/.templates/contributors/contributors.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/contributors.sbn
@@ -1,0 +1,9 @@
+
+
+__Contributors__
+
+{{ contributors.count }} contributors made this release possible.
+
+{{ for contributor in contributors.items
+    include 'contributor-details'
+end }}

--- a/.github/GitReleaseManager/.templates/contributors/create/footer.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/create/footer.sbn
@@ -1,0 +1,10 @@
+{{ if config.create.include_footer }}
+
+### {{ config.create.footer_heading }}
+
+{{  if config.create.milestone_replace_text
+        replace_milestone_title config.create.footer_content config.create.milestone_replace_text milestone.target.title
+    else
+        config.create.footer_content
+    end
+end }}

--- a/.github/GitReleaseManager/.templates/contributors/index.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/index.sbn
@@ -1,0 +1,13 @@
+{{-
+    include 'release-info'
+    if milestone.target.description
+        include 'milestone'
+    end
+    include 'issues' | string.rstrip
+    if contributors.count > 0
+        include 'contributors'
+    end
+    if template_kind == "CREATE"
+        include 'create/footer'
+    end
+~}}

--- a/.github/GitReleaseManager/.templates/contributors/issue-details.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/issue-details.sbn
@@ -1,0 +1,5 @@
+### {{ issue_label }}
+
+{{ for issue in issues.items[issue_label]
+    include 'issue-note'
+end }}

--- a/.github/GitReleaseManager/.templates/contributors/issue-note.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/issue-note.sbn
@@ -1,0 +1,45 @@
+{{
+func IssueDescription
+    if $0.is_pull_request
+        $description = "[__!" + $0.public_number + "__]"
+    else
+        $description = "[__#" + $0.public_number + "__]"
+    end
+    $description = $description + "(" + $0.html_url + ")"
+    if $1
+        $description = $0.title + " - see " + $description
+    end
+    if $0.user
+        $description = $description + " by [" + $0.user.login + "](" + $0.user.html_url + ")"
+    end
+    if $0.linked_issues
+        $description = $description + LinkedIssuesDescription($0.linked_issues) + "."
+    end
+    ret $description
+end
+func LinkedIssuesDescription
+    $countPRs = 0
+    $countIssues = 0
+    for linkedIssue in $0
+        if linkedIssue.is_pull_request
+            if $countPRs == 0
+                $resolvedBy = " resolved in "
+            else
+                $resolvedBy = $resolvedBy + ", "
+            end
+            $resolvedBy = $resolvedBy + IssueDescription(linkedIssue, false)
+            $countPRs = $countPRs + 1
+        else
+            if $countIssues == 0
+                $raisedIn = " raised in "
+            else
+                $raisedIn = $raisedIn + ", "
+            end
+            $raisedIn = $raisedIn + IssueDescription(linkedIssue, false)
+            $countIssues = $countIssues + 1
+        end
+    end
+    ret $raisedIn + $resolvedBy
+end
+}}
+- {{ IssueDescription(issue, true) }}

--- a/.github/GitReleaseManager/.templates/contributors/issues.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/issues.sbn
@@ -1,0 +1,4 @@
+
+{{ for issue_label in issue_labels
+    include 'issue-details'
+end }}

--- a/.github/GitReleaseManager/.templates/contributors/milestone.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/milestone.sbn
@@ -1,0 +1,2 @@
+
+{{ milestone.target.description }}

--- a/.github/GitReleaseManager/.templates/contributors/release-info.sbn
+++ b/.github/GitReleaseManager/.templates/contributors/release-info.sbn
@@ -1,0 +1,10 @@
+{{
+    if issues.count > 0
+        if commits.count > 0
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}) which resulted in [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?{{ milestone.query_string }}) being closed.
+{{      else
+}}As part of this release we had [{{ issues.count }} {{ issues.count | string.pluralize "issue" "issues" }}]({{ milestone.target.html_url }}?{{ milestone.query_string }}) closed.
+{{      end
+    else if commits.count > 0
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}).
+{{  end -}}

--- a/.github/GitReleaseManager/.templates/no/issues/create/footer.sbn
+++ b/.github/GitReleaseManager/.templates/no/issues/create/footer.sbn
@@ -1,0 +1,10 @@
+{{ if config.create.include_footer }}
+
+### {{ config.create.footer_heading }}
+
+{{  if config.create.milestone_replace_text
+        replace_milestone_title config.create.footer_content config.create.milestone_replace_text milestone.target.title
+    else
+        config.create.footer_content
+    end
+end }}

--- a/.github/GitReleaseManager/.templates/no/issues/index.sbn
+++ b/.github/GitReleaseManager/.templates/no/issues/index.sbn
@@ -1,0 +1,10 @@
+{{-
+    include 'release-info'
+    if milestone.target.description
+        include 'milestone'
+    end
+    include 'issues' | string.rstrip
+    if template_kind == "CREATE"
+        include 'create/footer'
+    end
+~}}

--- a/.github/GitReleaseManager/.templates/no/issues/issues.sbn
+++ b/.github/GitReleaseManager/.templates/no/issues/issues.sbn
@@ -1,0 +1,2 @@
+
+This release had no issues associated with it.

--- a/.github/GitReleaseManager/.templates/no/issues/milestone.sbn
+++ b/.github/GitReleaseManager/.templates/no/issues/milestone.sbn
@@ -1,0 +1,2 @@
+
+{{ milestone.target.description }}

--- a/.github/GitReleaseManager/.templates/no/issues/release-info.sbn
+++ b/.github/GitReleaseManager/.templates/no/issues/release-info.sbn
@@ -1,0 +1,4 @@
+{{
+    if commits.count > 0
+}}As part of this release we had [{{ commits.count }} {{ commits.count | string.pluralize "commit" "commits" }}]({{ commits.html_url }}).
+{{  end -}}

--- a/.github/GitReleaseManager/GitReleaseManager.yaml
+++ b/.github/GitReleaseManager/GitReleaseManager.yaml
@@ -25,8 +25,10 @@ create:
   include-sha-section: true
   sha-section-heading: "SHA256 Hashes of the release artifacts"
   sha-section-line-format: "- `{1}\t{0}`"
+  include-contributors: true
 close:
   use-issue-comments: true
+  set-due-date: true
   issue-comment: |-
     :tada: This issue has been resolved in version {milestone} :tada:
 


### PR DESCRIPTION
## Description Of Changes

Starting with GRM 0.19.0, there are two new features included.  One to
allow contributor information to be included in the generated release
notes, and another to set the due date on a milestone when closing it.
We want both of these things, so let's make sure to turn them on.

This new contributors template will be used to create release notes
which includes contributor information, i.e. who created the issue, and
who submitted the PR, etc.

There is a slight modification here to the default contributor template
that ships with GRM, but that is just to account for how Chocolatey
prefers to have release notes read.

## Motivation and Context

The ability to include contributor information is something that we have discussed having for a LONG time, so happy to see this finally landing!

## Testing

I used the template and configuration changes proposed in this PR to generate a set of release notes on a test repository (the release notes will be deleted, so can't include a link here), but the generated release notes were:

![image](https://github.com/user-attachments/assets/55fba6bf-fda3-416b-82dc-a7698693cb25)


### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

* ENGTASKS-4856