### PR TITLE
(maint) Reduce days before stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/stale@v9
         id: stale
         with:
-          days-before-stale: 30
+          days-before-stale: 14
           days-before-close: 14
           exempt-all-assignees: false
           exempt-draft-pr: true
@@ -32,25 +32,27 @@ jobs:
           remove-stale-when-updated: true
           stale-issue-message: |
             Is this still relevant? If so, what is blocking it? Is there anything you can do to help move it forward?
+
+
             This issue will be closed in 14 days if it continues to be inactive.
           close-issue-message: |
-            Dear contributor,
-
-            As this issue seems to have been inactive for quite some time now, it has been automatically closed.
+            As this issue has been inactive for some time, it has been automatically closed.
             If you feel this is a valid issue, please feel free to re-open the issue if / when a pull request
             has been added.
+
 
             Thank you for your contribution.
           stale-pr-message: |
             Is this still relevant? If so, what is blocking it? Is there anything you can do to help move it forward?
+
+
             This pull request will be closed in 14 days if it continues to be inactive.
           close-pr-message: |
-            Dear contributor,
+            As this pull request has been inactive for some time it has been automatically closed.
 
-            As this PR seems to have been inactive for 30 days after changes / additional information
-            was requested, it has been automatically closed.
 
-            If you feel the changes are still valid, please re-open the PR once all changes or additional information
-            that was requested has been added.
+            If you feel the changes are still valid, please re-open the pull request once the changes and / or the additional information
+            requested, has been added.
+
 
             Thank you for your contribution.


### PR DESCRIPTION
## Description Of Changes
The days before initially becoming stale has been changed to 14. 

## Motivation and Context
Along with the days before it's closed also being 14, this gives the contributor 28 days to respond from when changes are requested. As we don't lock issues, should it be closed, we can always reopen.

## Testing
N/A